### PR TITLE
SessionArrayWrapper and SessionContainer

### DIFF
--- a/src/Session.php
+++ b/src/Session.php
@@ -3,7 +3,7 @@ namespace Gt\Session;
 
 use SessionHandlerInterface;
 
-class Session {
+class Session implements SessionContainer {
 	const DEFAULT_SESSION_NAME = "PHPSESSID";
 	const DEFAULT_SESSION_LIFETIME = 0;
 	const DEFAULT_SESSION_PATH = "/tmp";

--- a/src/SessionArrayWrapper.php
+++ b/src/SessionArrayWrapper.php
@@ -1,0 +1,30 @@
+<?php
+namespace Gt\Session;
+
+class SessionArrayWrapper implements SessionContainer {
+	private $sourceArray;
+
+	public function __construct(array &$sourceArray) {
+		$this->sourceArray = &$sourceArray;
+	}
+
+	public function get(string $key) {
+		return $this->sourceArray[$key] ?? null;
+	}
+
+	public function set(string $key, $value) {
+		$this->sourceArray[$key] = $value;
+	}
+
+	public function contains(string $key):bool {
+		return isset($this->sourceArray[$key]);
+	}
+
+	public function remove(string $key):void {
+		if(!$this->contains($key)) {
+			return;
+		}
+
+		unset($this->sourceArray[$key]);
+	}
+}

--- a/src/SessionContainer.php
+++ b/src/SessionContainer.php
@@ -1,0 +1,9 @@
+<?php
+namespace Gt\Session;
+
+interface SessionContainer {
+	public function get(string $key);
+	public function set(string $key, $value);
+	public function contains(string $key):bool;
+	public function remove(string $key):void;
+}

--- a/src/SessionStore.php
+++ b/src/SessionStore.php
@@ -1,7 +1,7 @@
 <?php
 namespace Gt\Session;
 
-class SessionStore {
+class SessionStore implements SessionContainer {
 	/** @var string */
 	protected $name;
 	/** @var Session */

--- a/src/SessionStore.php
+++ b/src/SessionStore.php
@@ -8,7 +8,7 @@ class SessionStore {
 	protected $session;
 	/** @var SessionStore[] */
 	protected $stores;
-	/** @var string[] */
+	/** @var array */
 	protected $data;
 	/** @var SessionStore */
 	protected $parentStore;
@@ -22,6 +22,7 @@ class SessionStore {
 		$this->session = $session;
 		$this->parentStore = $parentStore;
 		$this->stores = [];
+		$this->data = [];
 	}
 
 	public function setData(string $key, $value):void {

--- a/test/unit/SessionArrayWrapperTest.php
+++ b/test/unit/SessionArrayWrapperTest.php
@@ -1,0 +1,50 @@
+<?php
+namespace Gt\Session\Test;
+
+use Gt\Session\SessionArrayWrapper;
+use PHPUnit\Framework\TestCase;
+
+class SessionArrayWrapperTest extends TestCase {
+	public function testContains() {
+		$sessionArray = [];
+		$key = uniqid();
+		$sut = new SessionArrayWrapper($sessionArray);
+		self::assertFalse($sut->contains($key));
+		$sut->set($key, "test-value");
+		self::assertTrue($sut->contains($key));
+	}
+
+	public function testSet() {
+		$sessionArray = [];
+		$key = uniqid();
+		$value = uniqid();
+		$sut = new SessionArrayWrapper($sessionArray);
+		$sut->set($key, $value);
+		self::assertEquals($value, $sessionArray[$key]);
+	}
+
+	public function testGet() {
+		$sessionArray = [];
+		$key = uniqid();
+		$value = uniqid();
+		$sut = new SessionArrayWrapper($sessionArray);
+		self::assertNull($sut->get($key));
+		self::assertArrayNotHasKey($key, $sessionArray);
+		$sut->set($key, $value);
+		self::assertEquals($value, $sut->get($key));
+		self::assertEquals($value, $sessionArray[$key]);
+	}
+
+	public function testRemove() {
+		$key = uniqid();
+		$value = uniqid();
+		$sessionArray = [
+			$key => $value,
+		];
+		$sut = new SessionArrayWrapper($sessionArray);
+		self::assertTrue($sut->contains($key));
+		$sut->remove($key);
+		self::assertFalse($sut->contains($key));
+		self::assertArrayNotHasKey($key, $sessionArray);
+	}
+}


### PR DESCRIPTION
One new class and an interface is provided here.

The `SessionContainer` interface defines extremely simple functionality: get, set, contains and remove functions. This interface is applied to the `Session` class and the contained `SessionStore` class.

Why introduce such a simple interface? This is so that other PHP.Gt applications built using WebEngine will be able to be build in a way that their components become inter-operable with other projects that do not use the PHP.Gt/Session functionality.

This is why the `SessionArrayWrapper` class has been introduced, which too also implements the `SessionContainer` interface. This class takes an array in the constructor and stores it internally by reference, which means projects that use the `$_SESSION` superglobal can now make use of PHP.Gt features, and vice-versa.