### PR TITLE
If session can not be opened, destroy first

### DIFF
--- a/src/Session.php
+++ b/src/Session.php
@@ -36,15 +36,23 @@ class Session implements SessionContainer {
 			$config["save_path"] ?? self::DEFAULT_SESSION_PATH
 		);
 		$sessionName = $config["name"] ?? self::DEFAULT_SESSION_NAME;
-		session_start([
-			"save_path" => $sessionPath,
-			"name" => $sessionName,
-			"cookie_lifetime" => $config["cookie_lifetime"] ?? self::DEFAULT_SESSION_LIFETIME,
-			"cookie_path" => $config["cookie_path"] ?? self::DEFAULT_COOKIE_PATH,
-			"cookie_domain" => $config["cookie_domain"] ?? self::DEFAULT_SESSION_DOMAIN,
-			"cookie_secure" => $config["cookie_secure"] ?? self::DEFAULT_SESSION_SECURE,
-			"cookie_httponly" => $config["cookie_httponly"] ?? self::DEFAULT_SESSION_HTTPONLY,
-		]);
+
+		do {
+			$success = @session_start([
+				"save_path" => $sessionPath,
+				"name" => $sessionName,
+				"cookie_lifetime" => $config["cookie_lifetime"] ?? self::DEFAULT_SESSION_LIFETIME,
+				"cookie_path" => $config["cookie_path"] ?? self::DEFAULT_COOKIE_PATH,
+				"cookie_domain" => $config["cookie_domain"] ?? self::DEFAULT_SESSION_DOMAIN,
+				"cookie_secure" => $config["cookie_secure"] ?? self::DEFAULT_SESSION_SECURE,
+				"cookie_httponly" => $config["cookie_httponly"] ?? self::DEFAULT_SESSION_HTTPONLY,
+			]);
+
+			if(!$success) {
+				session_destroy();
+			}
+		}
+		while(!$success);
 
 		$this->sessionHandler->open($sessionPath, $sessionName);
 		$this->store = $this->readSessionData() ?: null;

--- a/src/SessionStore.php
+++ b/src/SessionStore.php
@@ -8,7 +8,7 @@ class SessionStore {
 	protected $session;
 	/** @var SessionStore[] */
 	protected $stores;
-	/** @var string[] */
+	/** @var array */
 	protected $data;
 	/** @var SessionStore */
 	protected $parentStore;
@@ -22,6 +22,7 @@ class SessionStore {
 		$this->session = $session;
 		$this->parentStore = $parentStore;
 		$this->stores = [];
+		$this->data = [];
 	}
 
 	public function setData(string $key, $value):void {

--- a/test/unit/Helper/FunctionMocker.php
+++ b/test/unit/Helper/FunctionMocker.php
@@ -3,6 +3,7 @@ namespace Gt\Session\Test\Helper;
 
 class FunctionMocker {
 	public static $mockCalls = [];
+	public static $callState = [];
 
 	public static function mock(string $functionName) {
 		self::$mockCalls[$functionName] = [];

--- a/test/unit/Helper/FunctionOverride/session_destroy.php
+++ b/test/unit/Helper/FunctionOverride/session_destroy.php
@@ -1,0 +1,13 @@
+<?php
+namespace Gt\Session;
+
+use Gt\Session\Test\Helper\FunctionMocker;
+
+function session_destroy() {
+	if(FunctionMocker::$callState["session_start__fail"]) {
+		unset(FunctionMocker::$callState["session_start__fail"]);
+	}
+
+	FunctionMocker::$mockCalls["session_destroy"] []= func_get_args();
+	return true;
+}

--- a/test/unit/Helper/FunctionOverride/session_start.php
+++ b/test/unit/Helper/FunctionOverride/session_start.php
@@ -1,5 +1,14 @@
 <?php
 namespace Gt\Session;
+
+use Gt\Session\Test\Helper\FunctionMocker;
+
 function session_start() {
-	\Gt\Session\Test\Helper\FunctionMocker::$mockCalls["session_start"] []= func_get_args();
+	FunctionMocker::$mockCalls["session_start"] []= func_get_args();
+
+	if(FunctionMocker::$callState["session_start__fail"]) {
+		return false;
+	}
+
+	return true;
 }

--- a/test/unit/SessionTest.php
+++ b/test/unit/SessionTest.php
@@ -7,6 +7,7 @@ use Gt\Session\Test\Helper\DataProvider\ConfigProvider;
 use Gt\Session\Test\Helper\DataProvider\StringProvider;
 use Gt\Session\Test\Helper\FunctionMocker;
 use Gt\Session\Test\Helper\DataProvider\KeyValuePairProvider;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
 class SessionTest extends TestCase {
@@ -16,14 +17,17 @@ class SessionTest extends TestCase {
 
 	public function setUp():void {
 		FunctionMocker::mock("session_start");
+		FunctionMocker::mock("session_id");
+		FunctionMocker::mock("session_destroy");
 	}
 
 	public function testSessionStarts():void {
+		/** @var Handler|MockObject $handler */
 		$handler = $this->getMockBuilder(Handler::class)
 			->getMock();
 
 		self::assertEmpty(FunctionMocker::$mockCalls["session_start"]);
-		$session = new Session($handler);
+		new Session($handler);
 		self::assertCount(
 			1,
 			FunctionMocker::$mockCalls["session_start"]
@@ -34,10 +38,11 @@ class SessionTest extends TestCase {
 	 * @dataProvider data_randomConfig
 	 */
 	public function testSessionStartsWithConfig(array $config):void {
+		/** @var Handler|MockObject $handler */
 		$handler = $this->getMockBuilder(Handler::class)
 			->getMock();
 
-		$session = new Session($handler ,$config);
+		new Session($handler ,$config);
 		$sessionStartParameter = FunctionMocker::$mockCalls["session_start"][0][0];
 
 		foreach($config as $key => $value) {
@@ -49,7 +54,19 @@ class SessionTest extends TestCase {
 		}
 	}
 
+	/** @dataProvider data_randomConfig */
+	public function testSessionStartDestroysFailedSession(array $config):void {
+		/** @var Handler|MockObject $handler */
+		$handler = $this->getMockBuilder(Handler::class)
+			->getMock();
+
+		FunctionMocker::$callState["session_start__fail"] = true;
+		new Session($handler, $config);
+		self::assertCount(1, FunctionMocker::$mockCalls["session_destroy"]);
+	}
+
 	public function testWriteSessionDataCalled() {
+		/** @var Handler|MockObject $handler */
 		$handler = $this->getMockBuilder(Handler::class)
 			->getMock();
 		$handler->expects($this->exactly(2))
@@ -64,6 +81,7 @@ class SessionTest extends TestCase {
 	 * @dataProvider data_randomString
 	 */
 	public function testGetReturnsNull(string $randomString):void {
+		/** @var Handler|MockObject $handler */
 		$handler = $this->getMockBuilder(Handler::class)
 			->getMock();
 		$session = new Session($handler);
@@ -74,6 +92,7 @@ class SessionTest extends TestCase {
 	 * @@dataProvider data_randomKeyValuePairs
 	 */
 	public function testSetGet(array $keyValuePairs):void {
+		/** @var Handler|MockObject $handler */
 		$handler = $this->getMockBuilder(Handler::class)
 			->getMock();
 		$session = new Session($handler);
@@ -91,6 +110,7 @@ class SessionTest extends TestCase {
 	 * @dataProvider data_randomKeyValuePairs
 	 */
 	public function testSetGetNamespaced(array $keyValuePairs):void {
+		/** @var Handler|MockObject $handler */
 		$handler = $this->getMockBuilder(Handler::class)
 			->getMock();
 		$session = new Session($handler);
@@ -118,14 +138,15 @@ class SessionTest extends TestCase {
      * @dataProvider data_randomKeyValuePairs
      */
     public function testSetGetNamespacedSameParentNamespace(array $keyValuePairs):void {
-        $handler = $this->getMockBuilder(Handler::class)
-            ->getMock();
-        $session = new Session($handler);
+	/** @var Handler|MockObject $handler */
+	$handler = $this->getMockBuilder(Handler::class)
+	    ->getMock();
+	$session = new Session($handler);
 
-        $parentNamespace = implode(".", [
-            uniqid("namespace1-"),
-            uniqid("namespace2-"),
-        ]);
+	$parentNamespace = implode(".", [
+	    uniqid("namespace1-"),
+	    uniqid("namespace2-"),
+	]);
 
         foreach($keyValuePairs as $key => $value) {
             $newKey = implode(".", [
@@ -149,6 +170,7 @@ class SessionTest extends TestCase {
 	 * @@dataProvider data_randomKeyValuePairs
 	 */
 	public function testSetGetNotExistsOtherKey(array $keyValuePairs):void {
+		/** @var Handler|MockObject $handler */
 		$handler = $this->getMockBuilder(Handler::class)
 			->getMock();
 		$session = new Session($handler);
@@ -179,6 +201,7 @@ class SessionTest extends TestCase {
 	 * @dataProvider data_randomKeyValuePairs
 	 */
 	public function testContains(array $keyValuePairs):void {
+		/** @var Handler|MockObject $handler */
 		$handler = $this->getMockBuilder(Handler::class)
 			->getMock();
 		$session = new Session($handler);
@@ -196,6 +219,7 @@ class SessionTest extends TestCase {
 	 * @dataProvider data_randomKeyValuePairs
 	 */
 	public function testNotContains(array $keyValuePairs):void {
+		/** @var Handler|MockObject $handler */
 		$handler = $this->getMockBuilder(Handler::class)
 			->getMock();
 		$session = new Session($handler);
@@ -213,6 +237,7 @@ class SessionTest extends TestCase {
 	 * @dataProvider data_randomKeyValuePairs
 	 */
     public function testRemove(array $keyValuePairs):void {
+	    /** @var Handler|MockObject $handler */
 		$handler = $this->getMockBuilder(Handler::class)
 			->getMock();
 		$session = new Session($handler);
@@ -236,6 +261,7 @@ class SessionTest extends TestCase {
 	 * @dataProvider data_randomKeyValuePairs
 	 */
 	public function testNamespaceKeyIsRemovedFromSession(array $keyValuePairs):void {
+		/** @var Handler|MockObject $handler */
     		$handler = $this->getMockBuilder(Handler::class)
 			->getMock();
     		$session = new Session($handler);
@@ -279,6 +305,7 @@ class SessionTest extends TestCase {
 	 * @dataProvider data_randomKeyValuePairs
 	 */
 	public function testNamespaceKeyIsRemovedFromStore(array $keyValuePairs): void {
+		/** @var Handler|MockObject $handler */
 		$handler = $this->getMockBuilder(Handler::class)
 			->getMock();
 		$session = new Session($handler);
@@ -313,6 +340,7 @@ class SessionTest extends TestCase {
 	 * @dataProvider data_randomKeyValuePairs
 	 */
 	public function testRemoveNamespace(array $keyValuePairs) {
+		/** @var Handler|MockObject $handler */
 		$handler = $this->getMockBuilder(Handler::class)
 			->getMock();
 		$session = new Session($handler);
@@ -355,6 +383,7 @@ class SessionTest extends TestCase {
 	 * @dataProvider data_randomKeyValuePairs
 	 */
 	public function testRemoveSiblingNamespace(array $keyValuePairs) {
+		/** @var Handler|MockObject $handler */
 		$handler = $this->getMockBuilder(Handler::class)
 			->getMock();
 		$session = new Session($handler);

--- a/test/unit/phpunit.xml
+++ b/test/unit/phpunit.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <phpunit colors="true">
 	<testsuites>
-		<testsuite>
+		<testsuite name="main">
 			<directory suffix="Test.php">.</directory>
 		</testsuite>
 	</testsuites>


### PR DESCRIPTION
Closes #66 

> In the improbable (but possible) event that a session is corrupted (think load balanced app after being upgraded to new release), the session may not start without issuing a warning. This is fine, because if a session can't start, we should just destroy it and start again, but we need to handle this edge case.